### PR TITLE
refact: use shapely module for parallel curve

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ opencv-python-headless
 Pillow
 PyYAML
 scipy
+shapely
 tqdm

--- a/src/dipcoatimage/finitedepth/rectcoatinglayer.py
+++ b/src/dipcoatimage/finitedepth/rectcoatinglayer.py
@@ -828,7 +828,6 @@ def parallel_curve(curve: npt.NDArray, dist: float) -> npt.NDArray:
 
     Returns:
         Round-joint parallel curve of shape ``(V, 1, D)``.
-
     """
     if dist == 0:
         return curve


### PR DESCRIPTION
* `RectLayerShape.uniform_layer()` now returns polyline vertices instead of densely sampled points.
* `polyline_parallel_area()` is removed.
* `parallel_curve()` is introduced.

Close #267